### PR TITLE
Use assertEquals instead of assertTrue(... === ...)

### DIFF
--- a/test/ExpressiveInstallerTest/ContainersTest.php
+++ b/test/ExpressiveInstallerTest/ContainersTest.php
@@ -79,13 +79,7 @@ class ContainersTest extends OptionalPackagesTestCase
         // Test home page
         $setupRoutes = (strpos($copyFilesKey, 'minimal') !== 0);
         $response = $this->getAppResponse('/', $setupRoutes);
-        $status = $response->getStatusCode();
-
-        $this->assertEquals(
-            $expectedResponseStatusCode,
-            $status,
-            sprintf("Expected response status '%s', received '%s'", $expectedResponseStatusCode, $status)
-        );
+        $this->assertEquals($expectedResponseStatusCode, $response->getStatusCode());
     }
 
     public function containerProvider()

--- a/test/ExpressiveInstallerTest/ContainersTest.php
+++ b/test/ExpressiveInstallerTest/ContainersTest.php
@@ -81,12 +81,9 @@ class ContainersTest extends OptionalPackagesTestCase
         $response = $this->getAppResponse('/', $setupRoutes);
         $status = $response->getStatusCode();
 
-        // Using assertTrue here because when assertEquals failed when using FastRoute,
-        // it reported as a serialization error instead. See
-        // https://github.com/sebastianbergmann/phpunit/issues/1515
-        // for details. (Issue was never resolved)
-        $this->assertTrue(
-            $expectedResponseStatusCode === $status,
+        $this->assertEquals(
+            $expectedResponseStatusCode,
+            $status,
             sprintf("Expected response status '%s', received '%s'", $expectedResponseStatusCode, $status)
         );
     }

--- a/test/ExpressiveInstallerTest/RoutersTest.php
+++ b/test/ExpressiveInstallerTest/RoutersTest.php
@@ -95,13 +95,7 @@ class RoutersTest extends OptionalPackagesTestCase
         // Test home page
         $setupRoutes = (strpos($copyFilesKey, 'minimal') !== 0);
         $response = $this->getAppResponse('/', $setupRoutes);
-        $status = $response->getStatusCode();
-
-        $this->assertEquals(
-            $expectedResponseStatusCode,
-            $status,
-            sprintf("Expected response status '%s', received '%s'", $expectedResponseStatusCode, $status)
-        );
+        $this->assertEquals($expectedResponseStatusCode, $response->getStatusCode());
     }
 
     public function routerProvider()

--- a/test/ExpressiveInstallerTest/RoutersTest.php
+++ b/test/ExpressiveInstallerTest/RoutersTest.php
@@ -97,12 +97,9 @@ class RoutersTest extends OptionalPackagesTestCase
         $response = $this->getAppResponse('/', $setupRoutes);
         $status = $response->getStatusCode();
 
-        // Using assertTrue here because when assertEquals failed when using FastRoute,
-        // it reported as a serialization error instead. See
-        // https://github.com/sebastianbergmann/phpunit/issues/1515
-        // for details. (Issue was never resolved)
-        $this->assertTrue(
-            $expectedResponseStatusCode === $status,
+        $this->assertEquals(
+            $expectedResponseStatusCode,
+            $status,
             sprintf("Expected response status '%s', received '%s'", $expectedResponseStatusCode, $status)
         );
     }


### PR DESCRIPTION
Testes on Windows:

- PHPUnit 5.7.13
   - PHP 5.6.29
   - PHP 7.0.14
   - PHP 7.1.0
- PHPUnit 6.0.6
   - PHP 7.0.14
   - PHP 7.1.0

We can use `assertSame`. I've tested also on mac, but I don't remember specific version of php and phpunit.


Maybe we can remove also now 3rd param in `assertEquals`, not sure if it says anything more than just `assertEquals`.